### PR TITLE
Use 2nd most popular route for 6T to include missing stops

### DIFF
--- a/lib/tasks/stops.rake
+++ b/lib/tasks/stops.rake
@@ -44,7 +44,11 @@ namespace :stops do
     # for that tram line.
     data["data"]["routes"].each do |route|
       route["patterns"].sort_by! {|p| p["trips"].length }.reverse!
-      route["stops"] = route.delete("patterns").dig(0, "stops")
+      if route["shortName"] == "6T"
+        route["stops"] = route["patterns"][1]["stops"]
+      else
+        route["stops"] = route["patterns"][0]["stops"]
+      end
     end
 
     stops = {}


### PR DESCRIPTION
@matiaskorhonen this hack should include the missing stops, but will it cause presentation line 6T in the backwards direction in the app?